### PR TITLE
Added another root dir for ssl_ca_certs in order to work with OSX.

### DIFF
--- a/ghub.py
+++ b/ghub.py
@@ -38,7 +38,8 @@ class SafeHTTPSConnection(httplib.HTTPConnection):
     ca_cert_file_locations = (
         '/etc/ssl/cert.pem', '/etc/ssl/certs/ca-certificates.crt',
         '/usr/local/share/certs/ca-root-nss.crt',
-        '/etc/ssl/certs/ca-bundle.trust.crt')
+        '/etc/ssl/certs/ca-bundle.trust.crt',
+        '/usr/local/etc/openssl/cert.pem')
     default_port = 443
 
     def __init__(self, host, port=None, strict=None,


### PR DESCRIPTION
@ccstolley updated PR. 

``` I added another "ca_cert_file_locations" to work with my OSX. I have only tested this on my personal mac and it worked like a charm. I cant promise that this will work for every mac though.```