### PR TITLE
adding_ability_close_issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This tool is a work in progress.
 1. Install ghub:
     ```
     git clone git@github.com:ccstolley/ghub
-    
+
     cd ghub
-    
+
     python3 ./setup.py install
     ```
 2. Generate a personal access token from
@@ -87,21 +87,25 @@ optional arguments:
 ## Examples
 
 Display a specific issue:
-    
+
     ghub -i 442
 
 Post a comment to a specific issue:
 
     ghub -c 442
 
+Close a specific issue:
+
+    ghub -x 442
+
 List all open issues assigned to me in this repo:
-    
+
     ghub -i
-    
+
 List all unassigned open issues in this repo:
 
     ghub -i none
-    
+
 List issues assigned to ccstolley, including comments and summary:
 
     ghub -i ccstolley -v
@@ -117,7 +121,7 @@ Add reviewers to pull request:
 Display pull request and comments:
 
     ghub -p 101
-    
+
 Approve pull request:
 
     ghub -ok 101
@@ -127,5 +131,5 @@ Merge pull request:
     ghub -m 101
 
 Display pull request diff in color (requires cdiff):
-    
+
     ghub -d 101 | cdiff

--- a/ghub.py
+++ b/ghub.py
@@ -610,7 +610,7 @@ def create_issue(issue_text=None):
         print("Sorry, something bad happened: " + str(result))
 
 
-def close_issue(number, message=None):
+def close_issue(number, issue_text=None):
     """
     Closes an opened issue.
 
@@ -618,15 +618,14 @@ def close_issue(number, message=None):
 
     """
     (upstream_user, upstream_repo) = get_user_and_repo('upstream', 'origin')
-
-    if message:
-        data = json.dumps({'body': message}).encode('utf8')
+    if issue_text:
+        data = json.dumps({'body': issue_text}).encode('utf8')
         url = GITHUB_API_URL + '/repos/%s/%s/issues/%d/comments' % (
             upstream_user, upstream_repo, number)
         result = make_github_request(
             url, data, headers={'content-type': 'application/json'})
         if 'body' in result:
-            print_pull_request_comments(result)
+            pass
         else:
             print("Something bad happened: " + str(result))
 
@@ -639,7 +638,7 @@ def close_issue(number, message=None):
         url, data, method='PATCH', headers={'content-type': 'application/json'})
 
     if 'title' in result:
-        print("Closed issue #%d: %s" % (result['number'], result['title']))
+        print("Closed issue Number %d: Issue Tittle: %s" % (result['number'], result['title']))
     else:
         print("Sorry, something bad happened: " + str(result))
 
@@ -650,7 +649,6 @@ def post_issue_comment(number, msg=None):
 
     POST /repos/:owner/:repo/issues/:number/comments
     """
-    
     msg = msg or get_text_from_editor("\n# Enter comments for issue %d" % number)
 
     if not msg:
@@ -719,11 +717,7 @@ def main():
     parser.add_argument(
         '-o', '--openissue', help='create a new issue', action='store_true')
     parser.add_argument(
-        '-close', '--closeissue', help='close an issue #', action='store_true')
-    parser.add_argument(
-        '-append', '--appendcomment',
-        help='appends a comment directly from the commandline',
-        nargs='?', type=str, default='')
+        '-x', '--close', help='close an issue #', action='store_true')
     parser.add_argument(
         '-a', '--assign', help='assign an issue to login', metavar='login',
         nargs='?', type=str, default='')
@@ -766,12 +760,10 @@ def main():
     elif args.comment:
         post_issue_comment(_issue_number(), args.message)
     elif args.openissue:
-        create_issue()
-    elif args.closeissue:
-        close_issue(_issue_number(), args.appendcomment)
         args.message = [args.number]
         create_issue(args.message)
-
+    elif args.close:
+        close_issue(_issue_number(), args.message)
     elif args.assign:
         if not args.number:
             (args.number, args.assign) = (args.assign, None)

--- a/ghub.py
+++ b/ghub.py
@@ -619,15 +619,10 @@ def close_issue(number, issue_text=None):
     """
     (upstream_user, upstream_repo) = get_user_and_repo('upstream', 'origin')
     if issue_text:
-        data = json.dumps({'body': issue_text}).encode('utf8')
-        url = GITHUB_API_URL + '/repos/%s/%s/issues/%d/comments' % (
-            upstream_user, upstream_repo, number)
-        result = make_github_request(
-            url, data, headers={'content-type': 'application/json'})
-        if 'body' in result:
-            pass
-        else:
-            print("Something bad happened: " + str(result))
+        comment = post_issue_comment(number, issue_text)
+        if comment['status'] is False:
+            print("Aborting. Something bad happened when posting a comment: " + str(comment['content']))
+            raise SystemExit
 
     data = json.dumps({'state': 'closed'}).encode('utf8')
 
@@ -638,7 +633,7 @@ def close_issue(number, issue_text=None):
         url, data, method='PATCH', headers={'content-type': 'application/json'})
 
     if 'title' in result:
-        print("Closed issue Number %d: Issue Tittle: %s" % (result['number'], result['title']))
+        print("Closed issue #%d: %s" % (result['number'], result['title']))
     else:
         print("Sorry, something bad happened: " + str(result))
 
@@ -662,8 +657,10 @@ def post_issue_comment(number, msg=None):
         url, data, headers={'content-type': 'application/json'})
     if 'body' in result:
         print_pull_request_comments(result)
+        return {'status': True, 'content': str(result)}
     else:
         print("Something bad happened: " + str(result))
+        return {'status': False, 'content': str(result)}
 
 
 def assign_issue(number, assignee):


### PR DESCRIPTION
#13 << Related to this new functionality. This PR adds the functionality to be able to close issues from the CLI with the ability to comment if the user would like to. 

To close an issue without a comment
```
ghub -close 29
```
To close an issue with a comment
```
ghub -close 29 -append "Closing issue number 29, as it is now done!"
```