### PR TITLE
display_assignee_for_all_issues

### DIFF
--- a/ghub.py
+++ b/ghub.py
@@ -418,7 +418,8 @@ def print_pull_request(pr, verbose, reviews=None):
         print()
         print_pull_request_comments(pr['number'])
     else:
-        assignee = "@{}".format(pr['assignee']['login']) if pr['assignee'] is not None else ""
+        assignee = "[{}]".format(
+            colored(pr['assignee']['login'], 'yellow', ['bold'])) if pr.get('assignee') else ""
         print_tuple(pr['user']['login'][:12],
                     wrap_to_console('#%s %s %s' % (pr['number'], pr['title'], assignee))[0],
                     a_color='cyan')

--- a/ghub.py
+++ b/ghub.py
@@ -35,6 +35,7 @@ GHUB_SECRET_FILE = '.ghub'
 if sys.version_info[0:3] < (3, 4, 3):
     raise RuntimeError('Must use at least Python 3.4.3 or greater')
 
+
 def state_color(state):
     return {'open': 'green', 'closed': 'red'}.get(state.lower())
 
@@ -370,6 +371,7 @@ def print_pull_request_comments(comment_obj):
 
 def print_pull_request(pr, verbose, reviews=None):
     """Display pull requests or issues on screen."""
+
     if verbose:
         print_tuple('State', '%s' % (pr['state']),
                     b_color=state_color(pr['state']))
@@ -416,8 +418,9 @@ def print_pull_request(pr, verbose, reviews=None):
         print()
         print_pull_request_comments(pr['number'])
     else:
+        assignee = "@{}".format(pr['assignee']['login']) if pr['assignee'] is not None else ""
         print_tuple(pr['user']['login'][:12],
-                    wrap_to_console('#%s %s' % (pr['number'], pr['title']))[0],
+                    wrap_to_console('#%s %s %s' % (pr['number'], pr['title'], assignee))[0],
                     a_color='cyan')
 
 

--- a/ghub.py
+++ b/ghub.py
@@ -419,7 +419,7 @@ def print_pull_request(pr, verbose, reviews=None):
         print_pull_request_comments(pr['number'])
     else:
         assignee = "[{}]".format(
-            colored(pr['assignee']['login'], 'yellow', ['bold'])) if pr.get('assignee') else ""
+            colored(pr['assignee']['login'], 'blue', ['bold'])) if pr.get('assignee') else ""
         print_tuple(pr['user']['login'][:12],
                     wrap_to_console('#%s %s %s' % (pr['number'], pr['title'], assignee))[0],
                     a_color='cyan')

--- a/test_ghub.py
+++ b/test_ghub.py
@@ -107,7 +107,10 @@ class TestGhubFunctions(unittest.TestCase):
     @patch('ghub.get_pull_requests')
     def test_display_pull_requests__number(self, mock_req, mock_print):
         mock_req.return_value = {
-            'number': '1', 'title': 'pr1', 'user': {'login': 'foo'}}
+            'number': '1',
+            'title': 'pr1',
+            'user': {'login': 'foo'},
+            'assignee': None}
         ghub.display_pull_requests(verbose=False, number=1)
         self.assertRegex(mock_print.getvalue(), '#1 pr1')
 
@@ -122,7 +125,10 @@ class TestGhubFunctions(unittest.TestCase):
     def test_display_issues__number(self, mock_req, mock_print):
         print(mock_req)
         mock_req.return_value = {
-            'number': '1', 'title': 'issue1', 'user': {'login': 'foo'}}
+            'number': '1',
+            'title': 'issue1',
+            'user': {'login': 'foo'},
+            'assignee': None}
         ghub.display_issues('1')
         self.assertRegex(mock_print.getvalue(), '#1 issue1')
 


### PR DESCRIPTION
This PR displays assignees for all open issues by default. 

`ghub -i`
![image](https://user-images.githubusercontent.com/7788699/34471205-9bfc3aba-ef08-11e7-8981-37d91a0f01be.png)
